### PR TITLE
feat: add basic landing and chat pages

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,17 @@
+import Container from "@/components/Container";
+import MessageList from "@/components/MessageList";
+import MessageInput from "@/components/MessageInput";
+import { MessageProvider } from "@/hooks/message-provider";
+
+export default function ChatPage() {
+  return (
+    <Container>
+      <MessageProvider>
+        <div className="flex flex-col h-full w-full items-center">
+          <MessageList />
+          <MessageInput />
+        </div>
+      </MessageProvider>
+    </Container>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Inquisite",
@@ -24,11 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,18 @@
+import Link from "next/link";
+
 export default function Page() {
-  return <div></div>;
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-[#000] via-[#111] to-[#222] text-white p-4 text-center">
+      <h1 className="text-5xl font-bold mb-4">Inquisite</h1>
+      <p className="text-lg mb-8 max-w-md">
+        An all-inclusive personal knowledge generation and management system using premium AI models.
+      </p>
+      <Link
+        href="/chat"
+        className="px-6 py-3 rounded-xl bg-cyan-500 text-black font-medium hover:bg-cyan-400"
+      >
+        Get Started
+      </Link>
+    </main>
+  );
 }

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+export default function Container({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen w-full flex flex-col items-center bg-gradient-to-br from-[#000] via-[#111] to-[#222] text-white p-4">
+      {children}
+    </div>
+  );
+}

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useState } from "react";
+import { useMessage } from "@/hooks/message-provider";
+
+export default function MessageInput() {
+  const { sendMessage, loading } = useMessage();
+  const [value, setValue] = useState("");
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!value.trim()) return;
+        sendMessage(value);
+        setValue("");
+      }}
+      className="w-full max-w-xl flex gap-2"
+    >
+      <input
+        className="flex-1 rounded-xl border border-white/20 bg-white/5 px-3 py-2 focus:outline-none"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        disabled={loading}
+        placeholder="Type a message..."
+      />
+      <button
+        type="submit"
+        className="px-4 py-2 rounded-xl bg-cyan-500 text-black font-medium"
+        disabled={loading}
+      >
+        Send
+      </button>
+    </form>
+  );
+}

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useMessage } from "@/hooks/message-provider";
+
+export default function MessageList() {
+  const { messages } = useMessage();
+  return (
+    <div className="flex-1 w-full max-w-xl overflow-y-auto mb-4 flex flex-col gap-2">
+      {messages.map((m, idx) => (
+        <div key={idx} className="self-start rounded-xl bg-white/10 backdrop-blur p-3">
+          {m}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/message-provider.tsx
+++ b/src/hooks/message-provider.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { createContext, useContext, useState } from "react";
+
+type MessageContextValue = {
+  messages: string[];
+  loading: boolean;
+  sendMessage: (msg: string) => void;
+};
+
+const MessageContext = createContext<MessageContextValue | undefined>(undefined);
+
+export function MessageProvider({ children }: { children: React.ReactNode }) {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [loading] = useState(false);
+
+  const sendMessage = (msg: string) => {
+    setMessages((prev) => [...prev, msg]);
+  };
+
+  return (
+    <MessageContext.Provider value={{ messages, loading, sendMessage }}>
+      {children}
+    </MessageContext.Provider>
+  );
+}
+
+export function useMessage() {
+  const ctx = useContext(MessageContext);
+  if (!ctx) throw new Error("useMessage must be used within MessageProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- create landing page promoting Inquisite and link to chat
- add chat page with message list and input using context-based message store
- add simple Container component for consistent layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68972d0f3bd0832381992ebafa00b961